### PR TITLE
add an option to offset port-forward port numbers

### DIFF
--- a/src/clouds/azure/main.tf
+++ b/src/clouds/azure/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+	version = "3.116.0"
 	features {}
 }
 

--- a/src/helpers/expose-services.sh
+++ b/src/helpers/expose-services.sh
@@ -15,7 +15,7 @@ terminatePorts() {
     getPort "$service";
 
     set +e;
-    pid=$(pgrep -f "$service --namespace");
+    pid=$(pgrep -f "$service --namespace $namespace");
     set -e;
 
     if [[ -n "$pid" ]]; then

--- a/src/helpers/up/init-args.sh
+++ b/src/helpers/up/init-args.sh
@@ -27,6 +27,7 @@ SSLMode=$NONE;
 portsWait=15;
 deployments=$();
 flavor=$VANILLA;
+portforwardOffset=0;
 
 
 # Translate long argument flags into short ones.
@@ -44,13 +45,14 @@ for arg in "$@"; do
     '--dry-run')     set -- "$@" '-z'   ;;
     '--cloud')       set -- "$@" '-c'   ;;
     '--ssl')         set -- "$@" '-l'   ;;
+    '--port-offset') set -- "$@" '-p'   ;;
     *)               set -- "$@" "$arg" ;;
   esac
 done
 
 # Parse short options
 OPTIND=1;
-while getopts "hvn:f:e:r:s:d:zc:l" opt
+while getopts "hvn:f:e:r:s:d:zc:lp:" opt
 do
   case "$opt" in
     'h') usage; exit 0                 ;;
@@ -63,6 +65,7 @@ do
     'c') cloud=$OPTARG                 ;;
     's') storage=$OPTARG               ;;
     'l') SSLMode=$SSL                  ;;
+    'p') portforwardOffset=$OPTARG     ;;
     'd')
         IFS=',' read -r -a deployments <<< "$OPTARG";
         ;;

--- a/src/helpers/up/usage.sh
+++ b/src/helpers/up/usage.sh
@@ -18,4 +18,5 @@ usage() {
   echo -e "  -d, --deployments \tstring \t comma separated list of deployments to launch";
   echo -e "  -c, --cloud       \tenum   \t stand up k8s infrastructure in 'aws', 'gcp' or 'azure'. This will require Terraform and the CLIs associate with the cloud of choice";
   echo -e "  -l, --ssl         \tbool   \t enable ssl on deployments";
+  echo -e "  -p, --port-offset \tint   \t offset port number when using 'port-forward' to expose the services";
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add an option to offset port-forward port numbers by an integer.

This would allow multiple installations on localhost.

Example:
./up.sh tyk-stack
****************************************************************************************************
	Exposed Services
	dashboard-svc-tyk-stack-tyk-dashboard                        http://localhost:3000
	gateway-svc-tyk-stack-tyk-gateway                            http://localhost:8080
****************************************************************************************************

./up.sh --port-offset 1 tyk-stack
****************************************************************************************************
	Exposed Services
	dashboard-svc-tyk-stack-tyk-dashboard                        http://localhost:3001
	gateway-svc-tyk-stack-tyk-gateway                            http://localhost:8081
****************************************************************************************************

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## Test Coverage For This Change
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

Case 1. Two installations in different namespace:

1.1 Correct port-forward w.r.t --port-offset parameter

```
./up.sh --deployments operator --port-offset 0 --namespace tyk tyk-stack

****************************************************************************************************
	Exposed Services
	dashboard-svc-tyk-stack-tyk-dashboard                        http://localhost:3000
	gateway-svc-tyk-stack-tyk-gateway                            http://localhost:8080
****************************************************************************************************
```

```
./up.sh --port-offset 2 --namespace tyk2 tyk-stack

****************************************************************************************************
	Exposed Services
	dashboard-svc-tyk-stack-tyk-dashboard                        http://localhost:3002
	gateway-svc-tyk-stack-tyk-gateway                            http://localhost:8082
****************************************************************************************************
```

1.2 On termination, the correct port-forward process is killed
./down.sh --namespace tyk
./down.sh --namespace tyk2


Case 2: Two installations in different clusters

2.1 Correct port-forward w.r.t --port-offset parameter

```
kubectx cluster1
./up.sh --deployments operator --port-offset 0 --namespace tyk tyk-stack

****************************************************************************************************
	Exposed Services
	dashboard-svc-tyk-stack-tyk-dashboard                        http://localhost:3000
	gateway-svc-tyk-stack-tyk-gateway                            http://localhost:8080
****************************************************************************************************
```

```
kubectx cluster2
./up.sh --deployments operator --port-offset 1 --namespace tyk tyk-stack

****************************************************************************************************
	Exposed Services
	dashboard-svc-tyk-stack-tyk-dashboard                        http://localhost:3001
	gateway-svc-tyk-stack-tyk-gateway                            http://localhost:8081
****************************************************************************************************
```

2.2 On termination, the correct port-forward process is killed
```
kubectx cluster1
./down.sh --namespace tyk

kubectx cluster2
./down.sh --namespace tyk
```

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring or add test (improvements in base code or adds test coverage to functionality)
- [ ] Documentation updates or improvements.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] I have [reviewed the guidelines](./CONTRIBUTING.md) for contributing to this repository.
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
     - [ ] I have manually updated the README(s)/documentation accordingly.
     - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] When updating library version must provide reason/explanation for this update.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
    - [ ] `gofmt -s -w .`
    - [ ] `go vet ./...`
